### PR TITLE
manuell_fil_og_aapnet

### DIFF
--- a/docs/api/innrapportering-amelding.md
+++ b/docs/api/innrapportering-amelding.md
@@ -24,9 +24,11 @@ For generell informasjon om tjenestene se egne sider om:
 * [Teknisk spesifikasjon](../om/tekniskspesifikasjon.md)
 
 ## Status nye APIer
-Tilgjengelig i **produksjonsmiljø**: REST-api, [filopplasting-api](https://skatteetaten.github.io/api-dokumentasjon/api/innrapportering-amelding-filopplasting) og tilbakemelding
+Tilgjengelig i **produksjonsmiljø**: REST-api, [filopplasting-api](https://skatteetaten.github.io/api-dokumentasjon/api/innrapportering-amelding-filopplasting) og tilbakemelding.
 
-Tilgjengelig i **testmiljø**: REST-api, [filopplasting-api](https://skatteetaten.github.io/api-dokumentasjon/api/innrapportering-amelding-filopplasting) og tilbakemelding
+Tilgjengelig i **testmiljø**: REST-api, [filopplasting-api](https://skatteetaten.github.io/api-dokumentasjon/api/innrapportering-amelding-filopplasting) og tilbakemelding.
+
+Manuell filopplasting er også tilgjengelig i test: [Manuell filopplasting](https://ameldingfilopplasting.skatteetaten-test.no/web/amelding-filopplasting/) for XML-filer.
 
 Følg gjerne nyheter på [Nyheter for sluttbrukersystemer](https://www.skatteetaten.no/samarbeidspartnere/sluttbrukersystemer/sbs-nyheter/)
 
@@ -97,6 +99,30 @@ Tilsvarende for tilbakemeldingen ligger i Open API spesifikasjonen på
 [SwaggerHub tilbakemelding](https://app.swaggerhub.com/apis/skatteetaten/amelding-tilbakemelding-api/) 
 
 **VIKTIG!!** For å hente tilbakemeldingen må man lytte på hendelser hos Dialogporten. Dette er beskrevet hos Digdir: [Hvordan hente meldinger gjennom Dialogporten](https://samarbeid.digdir.no/altinn/hvordan-hente-meldinger-gjennom-dialogporten/2869)
+
+OBS OBS!!
+Informasjon angående m2m-uthenting av tilbakemeldingen via API:
+
+Forsendelsen (transmission-en) i Dialogporten inneholder to URL-er, som vist under.
+
+```json
+"urls": [
+            {
+              "id": "019e1687-...",
+              "url": "https://skatt-test.sits.no/web/aor-tilbakemelding/uthenting/v1/dialoger/019c27bc-...",
+              "mediaType": "application/json",
+              "consumerType": "Gui"               <<<—————— for nedlasting fra innboks
+            },
+            {
+              "id": "019e1687-...",
+              "url": "https://ameldingtilbakemelding.api.skatteetaten-test.no/v1/forsendelser/019e1687-...",
+              "mediaType": "application/json",
+              "consumerType": "Api"               <<<—————— for oppslag fra API
+            }
+          ]
+```
+
+Det er URL-en med "consumerType": "Api" som er grunnlag for oppslag mot tilbakemelding-API.
 
 
 

--- a/docs/api/innrapportering-amelding.md
+++ b/docs/api/innrapportering-amelding.md
@@ -24,9 +24,9 @@ For generell informasjon om tjenestene se egne sider om:
 * [Teknisk spesifikasjon](../om/tekniskspesifikasjon.md)
 
 ## Status nye APIer
-Tilgjengelig i **produksjonsmiljø**: REST-api, [filopplasting-api](https://skatteetaten.github.io/api-dokumentasjon/api/innrapportering-amelding-filopplasting) og tilbakemelding.
+Tilgjengelig i **produksjonsmiljø**: [REST-api](https://app.swaggerhub.com/apis/skatteetaten/innrapportering-amelding-api/), [filopplasting-api](https://skatteetaten.github.io/api-dokumentasjon/api/innrapportering-amelding-filopplasting) og [tilbakemelding](https://app.swaggerhub.com/apis/skatteetaten/amelding-tilbakemelding-api/).
 
-Tilgjengelig i **testmiljø**: REST-api, [filopplasting-api](https://skatteetaten.github.io/api-dokumentasjon/api/innrapportering-amelding-filopplasting) og tilbakemelding.
+Tilgjengelig i **testmiljø**: [REST-api](https://app.swaggerhub.com/apis/skatteetaten/innrapportering-amelding-api/), [filopplasting-api](https://skatteetaten.github.io/api-dokumentasjon/api/innrapportering-amelding-filopplasting) og [tilbakemelding](https://app.swaggerhub.com/apis/skatteetaten/amelding-tilbakemelding-api/).
 
 Manuell filopplasting er også tilgjengelig i test: [Manuell filopplasting](https://ameldingfilopplasting.skatteetaten-test.no/web/amelding-filopplasting/) for XML-filer.
 
@@ -100,10 +100,8 @@ Tilsvarende for tilbakemeldingen ligger i Open API spesifikasjonen på
 
 **VIKTIG!!** For å hente tilbakemeldingen må man lytte på hendelser hos Dialogporten. Dette er beskrevet hos Digdir: [Hvordan hente meldinger gjennom Dialogporten](https://samarbeid.digdir.no/altinn/hvordan-hente-meldinger-gjennom-dialogporten/2869)
 
-OBS OBS!!
-Informasjon angående m2m-uthenting av tilbakemeldingen via API:
-
-Forsendelsen (transmission-en) i Dialogporten inneholder to URL-er, som vist under.
+**OBS OBS!! Endring - foreløpig kun i testmiljø**
+I test har nå forsendelsen (transmission-en) i Dialogporten to URL-er, som vist under.
 
 ```json
 "urls": [
@@ -122,7 +120,10 @@ Forsendelsen (transmission-en) i Dialogporten inneholder to URL-er, som vist und
           ]
 ```
 
-Det er URL-en med "consumerType": "Api" som er grunnlag for oppslag mot tilbakemelding-API.
+**De systemene som allerede er i produksjon bør verifisere i test at de bruker riktig URL - slik at uthenting også vil fungere i produkjson når endringen deployes der.** 
+Nyhet om tidspunkt for endrigen i produksjon vil bli publisert på skatteetaten.no og Slack.   
+
+ 
 
 
 

--- a/docs/api/innrapportering-amelding.md
+++ b/docs/api/innrapportering-amelding.md
@@ -120,6 +120,10 @@ I test har nå forsendelsen (transmission-en) i Dialogporten to URL-er, som vist
           ]
 ```
 
+Gui-URLen må Skatteetaten ha for å gjøre tilbakemeldingen nedlastbar fra Dialogpottens innboks og Skatteetatens Min side.
+
+Api-URL er for oppslag for m2m-uthenting av tilbakemeldingen.
+
 **De systemene som allerede er i produksjon bør verifisere i test at de bruker riktig URL - slik at uthenting også vil fungere i produkjson når endringen deployes der.** 
 Nyhet om tidspunkt for endrigen i produksjon vil bli publisert på skatteetaten.no og Slack.   
 


### PR DESCRIPTION
Oppdatert sidene med info om manuell filopplasting og bruk av  Api-URL istedet for Gui-URL ved m2m-tilbakemelding.